### PR TITLE
Remove order details for exact printing

### DIFF
--- a/src/components/Receipt.tsx
+++ b/src/components/Receipt.tsx
@@ -1,4 +1,5 @@
 import { Order } from '@/contexts/POSContext';
+import { useEffect } from 'react';
 import { format } from 'date-fns';
 import { useSettings } from '@/contexts/SettingsContext';
 
@@ -12,6 +13,11 @@ const Receipt = ({ order, onClose }: ReceiptProps) => {
     window.print();
   };
   const { settings, formatCurrency } = useSettings();
+
+  useEffect(() => {
+    handlePrint();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div className="fixed inset-0 bg-background/80 backdrop-blur-sm z-50 flex items-center justify-center">
@@ -71,10 +77,12 @@ const Receipt = ({ order, onClose }: ReceiptProps) => {
                   <span>-{formatCurrency(order.costs.discount)}</span>
                 </div>
               )}
-              <div className="flex justify-between">
-                <span>Tax:</span>
-                <span>{formatCurrency(order.costs.tax)}</span>
-              </div>
+              {order.costs.tax > 0 && (
+                <div className="flex justify-between">
+                  <span>Tax:</span>
+                  <span>{formatCurrency(order.costs.tax)}</span>
+                </div>
+              )}
             </div>
             <div className="flex justify-between text-lg font-bold mt-2">
               <span>Total:</span>

--- a/src/pages/POS.tsx
+++ b/src/pages/POS.tsx
@@ -15,7 +15,7 @@ import {
   List
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import PaymentDialog from '@/components/PaymentDialog';
+// import PaymentDialog from '@/components/PaymentDialog';
 import { useSettings } from '@/contexts/SettingsContext';
 
 const POS = () => {
@@ -24,7 +24,7 @@ const POS = () => {
   const [selectedCategory, setSelectedCategory] = useState<string>('All');
   const [searchTerm, setSearchTerm] = useState('');
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
-  const [isPaymentOpen, setIsPaymentOpen] = useState(false);
+  // const [isPaymentOpen, setIsPaymentOpen] = useState(false);
 
   const categories = ['All', ...Array.from(new Set(menuItems.map(item => item.category)))];
 
@@ -248,7 +248,13 @@ const POS = () => {
                 <Button 
                   className="w-full" 
                   size="lg" 
-                  onClick={() => setIsPaymentOpen(true)}
+                  onClick={() => {
+                    createOrder({
+                      type: 'takeaway',
+                      payment: undefined,
+                      costs: { discount: 0, tax: 0 },
+                    });
+                  }}
                   disabled={cart.length === 0}
                 >
                   Checkout
@@ -259,14 +265,7 @@ const POS = () => {
         </Card>
       </div>
     </div>
-    <PaymentDialog
-      open={isPaymentOpen}
-      onOpenChange={setIsPaymentOpen}
-      subtotal={cartSubtotal}
-      onConfirm={({ type, payment, costs }) => {
-        createOrder({ type, payment, costs });
-      }}
-    />
+    {/* Payment dialog removed for quick checkout */}
     </>
   );
 };


### PR DESCRIPTION
Enable quick checkout by removing order type, payment methods, and tax, auto-printing receipts, and hiding zero tax rows.

---
<a href="https://cursor.com/background-agent?bcId=bc-4aba0b4b-267e-4c15-93e8-b6cd73485322">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4aba0b4b-267e-4c15-93e8-b6cd73485322">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

